### PR TITLE
Fixed Extension property not being cloned in ExceptionTelemetryBuilder

### DIFF
--- a/src/AppInsights/Builders/ExceptionTelemetryBuilder.cs
+++ b/src/AppInsights/Builders/ExceptionTelemetryBuilder.cs
@@ -22,12 +22,10 @@ namespace AppInsights.Builders
 
         internal ExceptionTelemetry Build()
         {
-            var exceptionTelemetry = (ExceptionTelemetry) _telemetry.DeepClone();
+            if (string.IsNullOrEmpty(_telemetry.Message))
+                _telemetry.Message = _telemetry.Exception.Message;
 
-            if (string.IsNullOrEmpty(exceptionTelemetry.Message))
-                exceptionTelemetry.Message = exceptionTelemetry.Exception.Message;
-
-            return exceptionTelemetry;
+            return _telemetry;
         }
 
         internal ExceptionTelemetryBuilder AddPowerShellContext(PowerShellHostContext hostContext, PowerShellCommandContext commandContext)


### PR DESCRIPTION
Hello, thank you for this module!

I noticed the extension property is set to null after calling the DeepClone method. This only happened when calling Send-AppInsightsException, so I fixed it in this PR.